### PR TITLE
Fix dockerfile, docker compose

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ COPY . /workspace/
 # Install dependencies global
 WORKDIR /workspace
 RUN pip -q install pipenv
-RUN pipenv install --system
+RUN pipenv install --system --skip-lock
 WORKDIR /
 
 RUN ["sh", "/workspace/.devcontainer/entrypoint.sh"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 {
 	"name": "Python 3 & PostgreSQL",
 	"dockerComposeFile": "docker-compose.yml",
-	"service": "app",
+	"service": "python",
 	"workspaceFolder": "/workspace",
 
 	// Set *default* container specific settings.json values on container create.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -49,6 +49,3 @@ services:
       - 8080:8080
     depends_on: 
       - db
-
-volumes:
-  postgres-data:

--- a/.prodcontainer/Dockerfile
+++ b/.prodcontainer/Dockerfile
@@ -8,7 +8,7 @@ COPY . /workspace/
 # Install dependencies global
 WORKDIR /workspace
 RUN pip -q install pipenv
-RUN pipenv install --system
+RUN pipenv install --system --skip-lock
 WORKDIR /
 
 ENTRYPOINT ["sh", "/workspace/.prodcontainer/entrypoint.sh"]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/emwiki/manage.py",
+            "pythonPath": "/usr/local/bin/python",
             "console": "integratedTerminal",
             "args": [
                 "runserver",

--- a/README.md
+++ b/README.md
@@ -99,14 +99,13 @@ cd .devcontainer
 docker-compose up -d --build
 ```
 + 以下をコンテナ内で実行
-  + pythonの実行時、以下のインタプリタを設定
-    + VSCodeの場合は、コマンドパレットから、`python select interpreter`から設定できる
-    ```
-    /usr/local/bin/python
-    ```
   + superuserの作成
     ```
     python manage.py createsuperuser
+    ```
+  + エラーが出る場合、以下のインタプリタが設定されているか確認する
+    ```
+    /usr/local/bin/python
     ```
 + 独自コマンド(実行する必要なし)
   + MML, HTMLizedMMLファイルの加工


### PR DESCRIPTION
## 目的
環境構築時のバグを修正した

## 関連するIssue等
+ 

## レビューポイント
+ 

## 留意事項
+ `--skip-lock`は、Pipenv.lockファイルを使用しないことを明記するため
+ devconainer.jsonの変更は、vscode以外影響なし
+ .devcontainer/docker-compose.ymlのpostgres-dataは、ホストPCに直接マウントしているためVolumeは使っていなかったので削除している
+ 

## 残課題
+ 