### PR TITLE
Remove MIZAR_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ git clone {your forked origin repository}
   + **(must)**`COMMENT_COMMIT_BRANCH`を`mml_commented`に設定
   + **(must)**`SQL_USER`を再設定
   + **(must)**`SQL_PASSWORD`を再設定
-  + **(must)**`MIZAR_VERSION`を再設定
   + その他の設定を適宜再設定
 + `.env.db`を、`.env.db-sample`を元に新たに作成
   + **(must)**`.env`に設定した`SQL_USER`の値を`POSTGRES_USER`に設定

--- a/emwiki/article/views.py
+++ b/emwiki/article/views.py
@@ -90,7 +90,7 @@ class CommentView(View):
         return HttpResponse(status=201)
 
 
-@cache_page(60 * 60 * 24 * 365, cache=settings.MIZAR_VERSION)
+@cache_page(60 * 60 * 24)
 def get_names(request):
     return HttpResponse(
         serializers.serialize(

--- a/emwiki/emwiki/settings.py
+++ b/emwiki/emwiki/settings.py
@@ -117,7 +117,6 @@ CACHES = {
     }
 }
 
-MIZAR_VERSION = os.environ.get("MIZAR_VERSION", 'default')
 
 
 # Internationalization

--- a/emwiki/symbol/views.py
+++ b/emwiki/symbol/views.py
@@ -38,7 +38,7 @@ def adjust_name(request):
         return HttpResponseNotFound
 
 
-@cache_page(60 * 60 * 24 * 365, cache=settings.MIZAR_VERSION)
+@cache_page(60 * 60 * 24)
 def get_names(request):
     return HttpResponse(
         serializers.serialize(


### PR DESCRIPTION
## 目的
cacheのバージョン管理を不要にする

## 関連するIssue等
+ 

## レビューポイント
+ cacheを一日ごとに削除することで、version管理を不要にしました。
+ 以前の方法は、バージョンごとにテーブルを作成する必要があり、バージョン管理には手動でdb操作が必要でした(管理者の手間が大きかった)
  + names APIはcacheしなくても数百msと早いので、一日ごとにcacheを削除する方法に変更しました。

## 留意事項
+ 

## 残課題
+ 