### PR TITLE
Fix bug in comment

### DIFF
--- a/emwiki/article/static/article/js/models/comment.js
+++ b/emwiki/article/static/article/js/models/comment.js
@@ -58,7 +58,7 @@ class Comment {
       data: {
         'article_name': this.article.name,
         'block': this.block,
-        'blockOrder': this.blockOrder,
+        'block_order': this.blockOrder,
         'comment': this.text,
       },
     }).done(function(data) {
@@ -120,7 +120,7 @@ class Comment {
       data: {
         article_name: comment.article.name,
         block: comment.block,
-        blockOrder: comment.blockOrder,
+        block_order: comment.blockOrder,
       },
     }).done(function(data) {
       comment.editor.text = data[0]['fields']['text'];


### PR DESCRIPTION
## 目的
コメントが送信できないバグの修正
## 関連するIssue等
+ fix #223 

## レビューポイント
+ バックエンドにキーを'block_order'としてコメントのorderを送信しなければらないが、eslintを追加した際に'blockOrder'に変更されていたため、これを元に戻すことで解決しました。

## 留意事項
+ 

## 残課題
+ 