### PR TITLE
Add paging to symbol drawer

### DIFF
--- a/emwiki/symbol/static/symbol/js/components/SymbolDrawer.js
+++ b/emwiki/symbol/static/symbol/js/components/SymbolDrawer.js
@@ -2,13 +2,6 @@ import {SymbolService} from '../services/symbol-service.js';
 import {context} from '../../../js/context.js';
 
 export const SymbolDrawer = {
-  methods: {
-    onSymbolRowClick(row) {
-      if (this.$route.params.name !== row.name) {
-        this.$router.push({name: 'Symbol', params: {name: row.name}});
-      }
-    },
-  },
   data: () => ({
     headers: [{text: 'type', value: 'type'}, {text: 'name', value: 'name'}],
     searchText: '',

--- a/emwiki/symbol/static/symbol/js/components/SymbolDrawer.js
+++ b/emwiki/symbol/static/symbol/js/components/SymbolDrawer.js
@@ -40,9 +40,9 @@ export const SymbolDrawer = {
               :headers="headers"
               :items="index"
               :search="searchText"
-              :items-per-page="-1"
+              :items-per-page="1000"
               dense
-              hide-default-footer
+              :footer-props="{'items-per-page-options': [100, 1000, 5000, -1]}"
               @click:row="onSymbolRowClick"
           >
           </v-data-table>


### PR DESCRIPTION
## 目的
9000件以上のシンボルがサイドバーにすべて表示されて動作が重くなっているため, ページングを実装し, 一度に表示される量を減らす。
## 関連するIssue等
+ Fix #244 

## レビューポイント
+ 以下のような形です。デフォルトは1000にしています。
![emwiki20220120](https://user-images.githubusercontent.com/60038502/150313493-5a94ce71-7d9e-4f1f-8fbf-3decd941366e.PNG)
+ クリック時
![emwiki20220120-2](https://user-images.githubusercontent.com/60038502/150313639-74a58cb1-6455-413d-9857-3106f61d1407.PNG)
 + 同じ関数が2重で書かれている部分があったので削除しました。



## 留意事項
+ 

## 残課題
+ 