### PR TITLE
Remove target pseudo-class's border  to symbol'css

### DIFF
--- a/emwiki/symbol/static/symbol/css/index.css
+++ b/emwiki/symbol/static/symbol/css/index.css
@@ -35,10 +35,6 @@ a[data-href]:hover {
     background: #adfff5;
 }
 
-:target{
-    border: 3px solid #007bff !important;
-}
-
 .mml-element.selected {
     border: 5px solid #2693ec;
 }


### PR DESCRIPTION
## 目的

## 関連するIssue等
+ Fix #251 

## レビューポイント
+  選択中の要素にボーダーをつける操作はselectedクラスを付与することで行っており, target疑似クラスによるボーダーの付与は不要なので消す.
+ target疑似要素はvue-routerでの遷移によって更新されず,  selectedクラスとtarget疑似クラスの両方に青いボーダーを設定していたことで #251 が発生していた模様.

## 留意事項
+ 

## 残課題
+ 