### PR TITLE
Remove unwanted elements from symbol html

### DIFF
--- a/emwiki/symbol/symbol_maker/writer.py
+++ b/emwiki/symbol/symbol_maker/writer.py
@@ -11,32 +11,17 @@ class Writer:
 
     def write(self, path):
         with codecs.open(path, 'w', 'utf-8-sig') as fp:
-            fp.write("<!DOCTYPE html>\n"
-                     "<html lang='en'>\n")
-            self.write_header(fp)
-            self.write_body(fp)
-            fp.write("</html>\n")
-
-    def write_header(self, fp):
-        fp.write(f'''
-                <head>
-                    <meta charset='UTF-8'>
-                    <title>{self.content.symbol}</title>
-                </head>
-                ''')
-
-    def write_body(self, fp):
-        fp.write('''
-            <body data-spy="scroll" data-target="#list-of-definitions">
-            <main class="container-fluid">
-            <div class="row">
-        ''')
-        self.content.write(fp)
-        fp.write('''
-            </div>
-            </main>
-            </body>
-        ''')
+            fp.write('''
+                <div data-spy="scroll" data-target="#list-of-definitions">
+                <div class="container-fluid">
+                <div class="row">
+            ''')
+            self.content.write(fp)
+            fp.write('''
+                </div>
+                </div>
+                </div>
+            ''')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 目的
不要なスクロールバーを削除し #250 を解決する
before:
![emwiki-before](https://user-images.githubusercontent.com/60038502/153760659-937f0f62-47d3-407c-85e6-ef04a44a42c0.PNG)
after: 
![emwiki-after](https://user-images.githubusercontent.com/60038502/153760668-71868bba-cd2e-4d78-aa65-9400a7a77d55.PNG)

## 関連するIssue等
+ Fix #250 

## レビューポイント
+ Symbol htmlに以下の変更を行いました。
    * DOCTYPE宣言を削除
    * html要素を削除
    * headerを削除
    * mainタグ, bodyタグをdivタグに変更

## 留意事項
+ この変更に伴うmml-filesの変更: https://github.com/mimosa-project/emwiki-mmlfiles/pull/7

## 残課題
+ 