### PR TITLE
Add style for #list-of-definitions

### DIFF
--- a/emwiki/symbol/static/symbol/css/index.css
+++ b/emwiki/symbol/static/symbol/css/index.css
@@ -4,9 +4,13 @@ body {
     margin: 0;
 }
 
-#list-of-definition {
+#list-of-definitions {
     overflow: auto;
-    max-height: 90vh;
+    /* ナビバー(64px)＋ 影(4px) */
+    top: 68px;
+    /* ナビバー(64px)＋ 影(4px) + colクラスのpadding(12px) */
+    height: calc(100vh - 80px);
+    padding-left: 1rem;
 }
 
 a[data-link] {


### PR DESCRIPTION
## 目的
画面サイズが大きい際に右側に表示されるシンボル定義一覧の以下の挙動を修正
 - シンボル定義一覧がスクロールできない
 - 画面全体を一番下までスクロールするとナビバーと重なり、ナビバーの手前に表示される。
## 関連するIssue等
+ Fix #249 

## レビューポイント
+ 画面上部からの高さや要素の高さを数値で指定してしまっている
## 留意事項
before:
https://github.com/mimosa-project/emwiki/issues/249#issue-1122181824

after:
https://user-images.githubusercontent.com/60038502/154299176-a818da99-9a38-4234-888b-1db51a9d461c.mp4


+ 

## 残課題
+ 