### PR TITLE
Remove bootstrap

### DIFF
--- a/emwiki/accounts/forms.py
+++ b/emwiki/accounts/forms.py
@@ -8,7 +8,7 @@ from accounts.models import User
 
 
 class MyUserCreationForm(UserCreationForm):
-    email = forms.EmailField(required=True)
+    email = forms.EmailField(label='Email', required=True)
 
     class Meta:
         model = User

--- a/emwiki/accounts/templates/accounts/email_change_complete.html
+++ b/emwiki/accounts/templates/accounts/email_change_complete.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<p>
-    Your email address has been changed.<br>
-</p>
+<v-container>
+    <p class="text-h4">Your email address has been changed.</p>
+</v-container>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/email_change_done.html
+++ b/emwiki/accounts/templates/accounts/email_change_done.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<p>
-    Click on the link in the email to change your email address.
-</p>
+<v-container>
+    <p class="text-h4">Click on the link in the email to change your email address.</p>
+</v-container>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/email_change_form.html
+++ b/emwiki/accounts/templates/accounts/email_change_form.html
@@ -1,15 +1,34 @@
 {% extends "base.html" %}
 {% block content %}
-<form action="" method="POST">
-    {{ form.non_field_errors }}
-    {% for field in form %}
-    <div class="form-group">
-        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
-        {{ field }}
-        {{ field.errors }}
-    </div>
-    {% endfor %}
-    {% csrf_token %}
-    <v-btn type="submit">Send</v-btn>
-</form>
+<v-row justify="center mt-5">
+    <v-col
+      cols="12"
+      sm="10"
+      md="8"
+      lg="6"
+    >
+        <v-card ref="form">
+            <form action="" method="post">
+                <v-card-text>
+                    <p class="text-h4 text--primary">New email</p>
+                    <div class="red--text">{{ form.non_field_errors }}</div>
+                    {% for field in form %}
+                        <v-text-field
+                          name="{{ field.name }}"
+                          label="{{ field.label }}"
+                          type="email"
+                          required
+                        ></v-text-field>
+                        <div class="red--text">{{ field.errors }}</div>
+                    {% endfor %}
+                    {% csrf_token %}
+                </v-card-text>
+                <v-divider class="mt-6"></v-divider>
+                <v-card-actions class="d-flex flex-row-reverse">
+                    <v-btn type="submit" block>Submit</v-btn>
+                </v-card-actions>
+            </form>
+      </v-card>
+    </v-col>
+</v-row>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/login.html
+++ b/emwiki/accounts/templates/accounts/login.html
@@ -1,23 +1,51 @@
 {% extends "base.html" %}
 
 {% block content %}
-<form action="" method="POST">
-    <div class="col-md-6 offset-md-3 mt-5">
-        <div class="card">
-            <div class="card-body">
-                {{ form.non_field_errors }}
-                {% for field in form %}
-                    {{ field }}
-                    {{ field.errors }}
-                    <hr>
-                {% endfor %}
-                <v-btn type="submit">Login</v-btn><hr>
-                <v-btn href="{% url 'accounts:signup' %}">Sign up</v-btn>
-                <v-btn href="{% url 'accounts:password_reset' %}">Password reset</v-btn>
-                <input type="hidden" name="next" value="{{ next }}" />
-                {% csrf_token %}
-            </div>
-        </div>
-    </div>
-</form>
+<v-row justify="center mt-5">
+    <v-col
+      cols="12"
+      sm="10"
+      md="8"
+      lg="6"
+    >
+        <v-card ref="form">
+            <form action="" method="post">
+                <v-card-text>
+                    <p class="text-h4 text--primary">Login</p>
+                    <div class="red--text">{{ form.non_field_errors }}</div>
+                    {% for field in form %}
+                        {% if field.name == "password" %}
+                            <v-text-field
+                              name="{{ field.name }}"
+                              label="{{ field.label }}"
+                              type="password"
+                              required
+                            ></v-text-field>
+                            <div class="red--text">{{ field.errors }}</div>
+                         {% else %}
+                             <v-text-field
+                             name="{{ field.name }}"
+                             label="{{ field.label }}"
+                             type="text"
+                             required
+                             ></v-text-field>
+                            <div class="red--text">{{ field.errors }}</div>
+                        {% endif %}
+                    {% endfor %}
+                    {% csrf_token %}
+                    <input type="hidden" name="next" value="{{ next }}" />
+                </v-card-text>
+                <v-divider class="mt-6"></v-divider>
+                <v-card-actions class="d-flex flex-row-reverse">
+                    <v-btn type="submit" block>Login</v-btn>
+                </v-card-actions>
+                <v-divider class="mt-6"></v-divider>
+                <v-card-actions class="d-flex justify-center">
+                    <v-btn href="{% url 'accounts:signup' %}">Sign up</v-btn>
+                    <v-btn href="{% url 'accounts:password_reset' %}">Password reset</v-btn>
+                </v-card-actions>
+            </form>
+      </v-card>
+    </v-col>
+</v-row>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/logout.html
+++ b/emwiki/accounts/templates/accounts/logout.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h1>Logged out</h1>
+<v-container>
+    <p class="text-h4">Logged out</p>
+</v-container>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/password_change.html
+++ b/emwiki/accounts/templates/accounts/password_change.html
@@ -1,15 +1,35 @@
 {% extends "base.html" %}
 {% block content %}
-<form action="" method="POST">
-    {{ form.non_field_errors }}
-    {% for field in form %}
-    <div class="form-group">
-        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
-        {{ field }}
-        {{ field.errors }}
-    </div>
-    {% endfor %}
-    {% csrf_token %}
-    <v-btn type="submit">Submit</v-btn>
-</form>
+<v-row justify="center mt-5">
+    <v-col
+      cols="12"
+      sm="10"
+      md="8"
+      lg="6"
+    >
+        <v-card ref="form">
+            <form action="" method="post">
+                <v-card-text>
+                    <p class="text-h4 text--primary">Change password</p>
+                    <div class="red--text">{{ form.non_field_errors }}</div>
+                    {% for field in form %}
+                        <v-text-field
+                          name="{{ field.name }}"
+                          label="{{ field.label }}"
+                          type="password"
+                          hint="It must contain at least 8 characters."
+                          required
+                        ></v-text-field>
+                        <div class="red--text">{{ field.errors }}</div>
+                    {% endfor %}
+                    {% csrf_token %}
+                </v-card-text>
+                <v-divider class="mt-6"></v-divider>
+                <v-card-actions>
+                    <v-btn type="submit" block>Submit</v-btn>
+                </v-card-actions>
+            </form>
+      </v-card>
+    </v-col>
+</v-row>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/password_change_done.html
+++ b/emwiki/accounts/templates/accounts/password_change_done.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
-<p>
-    Password has been changed.<br>
-    <a class="btn btn-primary btn-lg" href="{% url 'accounts:login' %}">Login</a>
-</p>
+<v-container>
+    <p class="text-h4">Password has been changed.</p>
+    <v-btn href="{% url 'accounts:login' %}">Login</v-btn>
+</v-container>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/password_reset_complete.html
+++ b/emwiki/accounts/templates/accounts/password_reset_complete.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
-<p>
-    Your password has been reset.<br>
-    <a class="btn btn-primary btn-lg" href="{% url 'accounts:login' %}">Login</a>
-</p>
+<v-container>
+    <p class="text-h4">Your password has been reset.</p>
+    <v-btn href="{% url 'accounts:login' %}">Login</v-btn>
+</v-container>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/password_reset_confirm.html
+++ b/emwiki/accounts/templates/accounts/password_reset_confirm.html
@@ -1,15 +1,35 @@
 {% extends "base.html" %}
 {% block content %}
-<form action="" method="POST">
-    {{ form.non_field_errors }}
-    {% for field in form %}
-    <div class="form-group">
-        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
-        {{ field }}
-        {{ field.errors }}
-    </div>
-    {% endfor %}
-    {% csrf_token %}
-    <v-btn type="submit">Send</v-btn>
-</form>
+<v-row justify="center mt-5">
+    <v-col
+      cols="12"
+      sm="10"
+      md="8"
+      lg="6"
+    >
+        <v-card ref="form">
+            <form action="" method="post">
+                <v-card-text>
+                    <p class="text-h4 text--primary">New password</p>
+                    <div class="red--text">{{ form.non_field_errors }}</div>
+                    {% for field in form %}
+                        <v-text-field
+                          name="{{ field.name }}"
+                          label="{{ field.label }}"
+                          type="password"
+                          hint="It must contain at least 8 characters."
+                          required
+                        ></v-text-field>
+                        <div class="red--text">{{ field.errors }}</div>
+                    {% endfor %}
+                    {% csrf_token %}
+                </v-card-text>
+                <v-divider class="mt-6"></v-divider>
+                <v-card-actions>
+                    <v-btn type="submit" block>Submit</v-btn>
+                </v-card-actions>
+            </form>
+      </v-card>
+    </v-col>
+</v-row>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/password_reset_done.html
+++ b/emwiki/accounts/templates/accounts/password_reset_done.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<p>
-    Check your inbox for an email from us with a link to reset your password.
-</p>
+<v-container>
+    <p class="text-h4">Check your inbox for an email from us with a link to reset your password.</p>
+</v-container>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/password_reset_form.html
+++ b/emwiki/accounts/templates/accounts/password_reset_form.html
@@ -1,15 +1,35 @@
 {% extends "base.html" %}
 {% block content %}
-<form action="" method="POST">
-    {{ form.non_field_errors }}
-    {% for field in form %}
-    <div class="form-group">
-        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
-        {{ field }}
-        {{ field.errors }}
-    </div>
-    {% endfor %}
-    {% csrf_token %}
-    <v-btn type="submit">Send</v-btn>
-</form>
+
+<v-row justify="center mt-5">
+    <v-col
+      cols="12"
+      sm="10"
+      md="8"
+      lg="6"
+    >
+        <v-card ref="form">
+            <form action="" method="post">
+                <v-card-text>
+                    <p class="text-h4 text--primary">Password Reset</p>
+                    {{ form.non_field_errors }}
+                    {% for field in form %}
+                        <v-text-field
+                          name="{{ field.name }}"
+                          label="{{ field.label }}"
+                          type="email"
+                          required
+                        ></v-text-field>
+                        <div class="red--text">{{ field.errors }}</div>
+                    {% endfor %}
+                    {% csrf_token %}
+                </v-card-text>
+                <v-divider class="mt-6"></v-divider>
+                <v-card-actions>
+                    <v-btn type="submit" block>Send</v-btn>
+                </v-card-actions>
+            </form>
+      </v-card>
+    </v-col>
+</v-row>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/signup.html
+++ b/emwiki/accounts/templates/accounts/signup.html
@@ -1,16 +1,54 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<form action="" method="POST">
-    {{ form.non_field_errors }}
-    {% for field in form %}
-    <div class="form-group">
-        <label for="{{ field.id_for_label }}">{{ field.label_tag }}</label>
-        {{ field }}
-        {{ field.errors }}
-    </div>
-    {% endfor %}
-    {% csrf_token %}
-    <v-btn type="submit">Submit</v-btn>
-</form>
+<v-row justify="center mt-5">
+    <v-col
+      cols="12"
+      sm="10"
+      md="8"
+      lg="6"
+    >
+        <v-card ref="form">
+            <form action="" method="post">
+                <v-card-text>
+                    <p class="text-h4 text--primary">Sign up</p>
+                    <div class="red--text">{{ form.non_field_errors }}</div>
+                    {% for field in form %}
+                        {% if "password" in field.name %}
+                            <v-text-field
+                              name="{{ field.name }}"
+                              label="{{ field.label }}"
+                              type="password"
+                              hint="It must contain at least 8 characters."
+                              required
+                            ></v-text-field>
+                            <div class="red--text">{{ field.errors }}</div>
+                        {% elif field.name == "email" %}
+                            <v-text-field
+                            name="{{ field.name }}"
+                            label="{{ field.label }}"
+                            type="email"
+                            required
+                            ></v-text-field>
+                           <div class="red--text">{{ field.errors }}</div>
+                         {% else %}
+                             <v-text-field
+                             name="{{ field.name }}"
+                             label="{{ field.label }}"
+                             type="text"
+                             required
+                             ></v-text-field>
+                            <div class="red--text">{{ field.errors }}</div>
+                        {% endif %}
+                    {% endfor %}
+                    {% csrf_token %}
+                </v-card-text>
+                <v-divider class="mt-6"></v-divider>
+                <v-card-actions>
+                    <v-btn type="submit" block>Submit</v-btn>
+                </v-card-actions>
+            </form>
+      </v-card>
+    </v-col>
+</v-row>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/user_detail.html
+++ b/emwiki/accounts/templates/accounts/user_detail.html
@@ -1,22 +1,49 @@
 {% extends "base.html" %}
 {% block content %}
-<table class="table">
-    <tbody>
-        <tr>
-            <th>Username</th>
-            <td>{{ user.username }}</td>
-            <td><v-btn href="{% url 'accounts:user_update' user.pk %}">Change</v-btn></td>
-        </tr>
-        <tr>
-            <th>Email</th>
-            <td>{{ user.email }}</td>
-            <td><v-btn href="{% url 'accounts:email_change' %}">Change</v-btn></td>
-        </tr>
-        <tr>
-            <th>Password</th>
-            <td>●●●●●●●●●●●</td>
-            <td><v-btn href="{% url 'accounts:password_change' %}">Change</v-btn></td>
-        </tr>
-    </tbody>
-</table>
+<v-row justify="center mt-5">
+    <v-col
+      cols="12"
+      sm="10"
+      md="8"
+      lg="6"
+    >
+        <v-card ref="form">
+            <form action="" method="post">
+                <v-card-text>
+                    <p class="text-h4 text--primary mb-12">User Information</p>
+                    <v-row class="d-flex">
+                        <v-col class="font-weight-black">Username:</v-col>
+                        <v-col class="mr-auto">{{ user.username }}</v-col>
+                        <v-col>
+                            <v-btn class="ml-auto" href="{% url 'accounts:user_update' user.pk %}">
+                                <v-icon>mdi-pencil</v-icon>
+                            </v-btn>
+                        </v-col>
+                    </v-row>
+                    <v-divider class="mb-3"></v-divider>
+                    <v-row class="d-flex">
+                        <v-col class="font-weight-black">Email:</v-col>
+                        <v-col class="mr-auto">{{ user.email }}</v-col>
+                        <v-col>
+                            <v-btn class="ml-auto" href="{% url 'accounts:email_change' %}">
+                                <v-icon>mdi-pencil</v-icon>
+                            </v-btn>
+                        </v-col>
+                    </v-row>
+                    <v-divider class="mb-3"></v-divider>
+                    <v-row class="d-flex">
+                        <v-col class="font-weight-black">Password:</v-col>
+                        <v-col class="mr-auto">●●●●●●●●●●●</v-col>
+                        <v-col>
+                            <v-btn class="ml-auto" href="{% url 'accounts:password_change' %}">
+                                <v-icon>mdi-pencil</v-icon>
+                            </v-btn>
+                        </v-col>
+                    </v-row>
+                    <v-divider class="mb-3"></v-divider>
+                </v-card-text>
+            </form>
+      </v-card>
+    </v-col>
+</v-row>
 {% endblock %}

--- a/emwiki/accounts/templates/accounts/user_form.html
+++ b/emwiki/accounts/templates/accounts/user_form.html
@@ -1,18 +1,35 @@
 {% extends "base.html" %}
 {% block content %}
-<form action="" method="POST">
-    {{ form.non_field_errors }}
-    <table class="table">
-        <tbody>
-            {% for field in form %}
-                <tr>
-                    <th><label for="{{ field.id_for_label }}">{{ field.label }}</label></th>
-                    <td>{{ field }} {{ field.errors }}</td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    {% csrf_token %}
-    <v-btn type="submit">Submit</v-btn>
-</form>
+
+<v-row justify="center mt-5">
+    <v-col
+      cols="12"
+      sm="10"
+      md="8"
+      lg="6"
+    >
+        <v-card ref="form">
+            <form action="" method="post">
+                <v-card-text>
+                    <p class="text-h4 text--primary">New Username</p>
+                    <div class="red--text">{{ form.non_field_errors }}</div>
+                    {% for field in form %}
+                        <v-text-field
+                          name="{{ field.name }}"
+                          label="{{ field.label }}"
+                          type="text"
+                          required
+                        ></v-text-field>
+                        <div class="red--text">{{ field.errors }}</div>
+                    {% endfor %}
+                    {% csrf_token %}
+                </v-card-text>
+                <v-divider class="mt-6"></v-divider>
+                <v-card-actions class="d-flex flex-row-reverse">
+                    <v-btn type="submit" block>Submit</v-btn>
+                </v-card-actions>
+            </form>
+      </v-card>
+    </v-col>
+</v-row>
 {% endblock %}

--- a/emwiki/article/static/article/js/components/ArticleDrawer.js
+++ b/emwiki/article/static/article/js/components/ArticleDrawer.js
@@ -62,10 +62,10 @@ export const ArticleDrawer = {
         @click:row="onArticleRowClick"
     >
         <template v-slot:item.name="props">
-            <p 
-                class="m-0 p-2" 
-                v-html="queryText === '' 
-                    ? props.item.name 
+            <p
+                class="mb-0 py-2"
+                v-html="queryText === ''
+                    ? props.item.name
                     : props.item.highlightedName"
             >
             </p>

--- a/emwiki/article/static/article/js/components/TheoremDrawer.js
+++ b/emwiki/article/static/article/js/components/TheoremDrawer.js
@@ -77,7 +77,7 @@ export const TheoremDrawer = {
         :disabled="isAscii(searchText) !== true"
       >
         <v-progress-circular indeterminate v-if="loading" color="primary" />
-        <p v-else class="m-auto">Search</p>
+        <p v-else class="mb-0">Search</p>
       </v-btn>
     </v-form>
     <v-list :height="searchHeight" class="overflow-auto">
@@ -95,7 +95,7 @@ export const TheoremDrawer = {
                 relevance: $(theoremModel.relevance)
               </v-chip>
               <v-btn
-                @click.stop="recordReactions(theoremModel.id, 'fav')" 
+                @click.stop="recordReactions(theoremModel.id, 'fav')"
                 :id="'fav-btn-' + theoremModel.id"
               >
                 <v-icon color="blue">mdi-thumb-up</v-icon>

--- a/emwiki/symbol/static/symbol/js/components/SymbolDrawer.js
+++ b/emwiki/symbol/static/symbol/js/components/SymbolDrawer.js
@@ -53,7 +53,7 @@ export const SymbolDrawer = {
           >
             <template v-slot:item.name="props">
                 <p
-                    class="m-0 p-2"
+                    class="mb-0 py-2"
                     v-html="queryText === ''
                         ? props.item.name
                         : props.item.highlightedName"

--- a/emwiki/symbol/symbol_maker/content.py
+++ b/emwiki/symbol/symbol_maker/content.py
@@ -21,29 +21,29 @@ class Content:
         return str(self.id) + '.html'
 
     def write(self, fp):
-        fp.write('<div id="content" class="col-9 pl-3">')
+        fp.write('<v-col cols="9" id="content" class="pl-6">')
         self.write_summary(fp)
         for i, e in enumerate(self.elements):
             e.write(fp, i + 1)
-        fp.write('</div>')
+        fp.write('</v-col>')
 
-        fp.write('<div id="scrollspy" class="col-3" >')
+        fp.write('<v-col cols="3" id="scrollspy">')
         self.write_scrollspy(fp)
-        fp.write('</div>')
+        fp.write('</v-col>')
 
     def write_summary(self, fp):
         rep = self.elements[0]
         fp.write(f'''
             <div class="mml-summary">
-                <h1 class="d-inline">{self.escape_html_characters(rep.symbol)}</h1>
-                <hr class="mb-0">
-                <h4 class="mb-5">{rep.type()}</h4>
+                <p class="text-h2">{self.escape_html_characters(rep.symbol)}</p>
+                <v-divider></v-divider>
+                <p class="text-h4 mb-5">{rep.type()}</p>
         ''')
 
         fp.write(f'''
-                <div class='card mb-5'>
-                    <div class='card-body'>
-                        <h5 class='card-title'>List of Definitions ({str(len(self.elements))})</h5>
+                <v-card outlined class="px-5 py-3">
+                    <div>
+                        <p class='text-h5'>List of Definitions ({str(len(self.elements))})</p>
                         <ol class='section-nav'>
         ''')
         for i, e in enumerate(self.elements):
@@ -55,15 +55,17 @@ class Content:
         fp.write('''
                         </ol>
                     </div>
-                </div>
+                </v-card>
             </div>
         ''')
 
     def write_scrollspy(self, fp):
         fp.write(f'''
-            <nav id="list-of-definitions" class="d-none d-xl-block bd-toc sticky-top" aria-label="Secondary navigation">
-                <h4>{str(len(self.elements))} Definitions</h4>
-                <ol class="section-nav">
+            <nav id="list-of-definitions" class="d-none d-lg-block" style="position: sticky;" aria-label="Secondary navigation">
+                <v-card outlined>
+                    <v-card-title>{str(len(self.elements))} Definitions</v-card-title>
+                    <v-card-text class="body-1">
+                        <ol class="section-nav">
         ''')
 
         for i, e in enumerate(self.elements):
@@ -74,6 +76,8 @@ class Content:
             ''')
 
         fp.write('''
-                </ol>
+                        </ol>
+                    </v-card-text">
+                </v-card>
             </nav>
         ''')

--- a/emwiki/symbol/symbol_maker/elements/element.py
+++ b/emwiki/symbol/symbol_maker/elements/element.py
@@ -180,17 +180,15 @@ class Element:
 
     def write(self, fp, i):
         fp.write(f'''
-            <div class='card mml-element mt-2'  id='{self.html_id()}'>
-                <div class='card-header'>
+            <v-card class='mml-element pa-4 my-3' id='{self.html_id()}'>
+                <v-card-title class="grey lighten-3">
                     <h3>{str(i)}. {self.element_link_html(self)} [{self.source_link_html(self)}]</h3>
-                </div>
-                <div class='card-body'>
+                </v-card-title>
         ''')
         self.write_source_code(fp)
         self.write_relations(fp)
         fp.write('''
-                </div>
-            </div>
+            </v-card>
         ''')
 
     @staticmethod
@@ -212,10 +210,10 @@ class Element:
             source_code = html.tostring(self.defblock, pretty_print=True, encoding='utf-8').decode('utf-8')
             fp.write(f'''
                 <div class='source'>
-                    <h4>Source <span class='defined-in'> [{self.source_link_html(self)}]</span></h4>
-                    <div class='source-box bg-light p-3'>
+                    <div class="text-h5 pa-4 pb-2">Source <span class='defined-in'> [{self.source_link_html(self)}]</span></div>
+                    <v-card-text class='source-box grey lighten-4 body-1'>
                         {source_code}
-                    </div>
+                    </v-card-text>
                 </div>
             ''')
         finally:

--- a/emwiki/symbol/symbol_maker/writer.py
+++ b/emwiki/symbol/symbol_maker/writer.py
@@ -12,15 +12,13 @@ class Writer:
     def write(self, path):
         with codecs.open(path, 'w', 'utf-8-sig') as fp:
             fp.write('''
-                <div data-spy="scroll" data-target="#list-of-definitions">
-                <div class="container-fluid">
-                <div class="row">
+                <v-container fluid>
+                <v-row>
             ''')
             self.content.write(fp)
             fp.write('''
-                </div>
-                </div>
-                </div>
+                </v-row>
+                </v-container>
             ''')
 
 

--- a/emwiki/templates/base.html
+++ b/emwiki/templates/base.html
@@ -10,8 +10,8 @@
   <title>emwiki</title>
 
   <!-- Bootstrap CSS -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
-    integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+  <!-- <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" -->
+    <!-- integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous"> -->
 
   <!-- jQuery -->
   <script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="
@@ -37,7 +37,7 @@
   <!-- Axios -->
   <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 
-  {% block head %}{% endblock %} 
+  {% block head %}{% endblock %}
 </head>
 
 <body>
@@ -51,7 +51,7 @@
       <v-app-bar app height="64px">
         <v-app-bar-nav-icon v-if="menuButton" @click="drawerExists = !drawerExists"></v-app-bar-nav-icon>
         <v-toolbar-title>emwiki</v-toolbar-title>
-        
+
         <v-spacer></v-spacer>
 
         <v-btn href="{% url 'home:index' %}" text>Home</v-btn>
@@ -59,7 +59,7 @@
         <v-btn href="{% url 'symbol:index' '0' %}" text>Symbol</v-btn>
         <v-btn href="{% url 'article:index' 'abcmiz_0' %}?target=theorem" text>Theorem</v-btn>
         <v-btn href="{% url 'graph:index' %}" text>Graph</v-btn>
-        
+
         <v-menu offset-y>
           {% if user.is_authenticated %}
             <template v-slot:activator="{ on, attrs }">
@@ -105,7 +105,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW"
     crossorigin="anonymous"></script>
-  
+
   <!-- base CSS, JavaScript -->
   <link rel='stylesheet' href="{% static 'css/base.css' %}" type='text/css'>
   </link>

--- a/emwiki/templates/base.html
+++ b/emwiki/templates/base.html
@@ -9,9 +9,6 @@
 
   <title>emwiki</title>
 
-  <!-- Bootstrap CSS -->
-  <!-- <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" -->
-    <!-- integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous"> -->
 
   <!-- jQuery -->
   <script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk="


### PR DESCRIPTION
## 目的
 + Bootstrapで記述されているhtml(Symbol, account)をVuetifyで書き換える。
 + 現在signupページでemail入力欄のlabelがnoneになっているバグを修正
![emwiki-old-signup](https://user-images.githubusercontent.com/60038502/157253781-48573282-e518-4dc7-a4cf-789f5f27becc.PNG)

## 関連するIssue等
+ #222 

## レビューポイント
変更後のアカウント(一部)
![emwiki-user-info](https://user-images.githubusercontent.com/60038502/157253248-f3bf2a09-69d2-4fd9-a428-e17079e2e2e3.PNG)
![emwiki-login](https://user-images.githubusercontent.com/60038502/157253257-14ff8b0e-df98-4762-b524-28c4ddd1480a.PNG)
![emwiki-account](https://user-images.githubusercontent.com/60038502/157253260-f9d78870-b1c7-4bf7-8b0c-b34310681930.PNG)
変更後のシンボル
![emwiki-symbol](https://user-images.githubusercontent.com/60038502/157253253-e85e46de-e727-428a-b0ad-b298c52fe300.PNG)
## 留意事項


このPRが承認された後
1. 変更後のsymbol-htmlを圧縮しemwiki-mmlfilesにPRを作成する
2. emwiki-mmlfilesのPRが承認された後に、 最新のemwiki-mmlfilesを参照するためのemwikiのPRを作成する

## 残課題
+ 