### PR TITLE
Improve loading times

### DIFF
--- a/emwiki/article/static/article/js/models/comment.js
+++ b/emwiki/article/static/article/js/models/comment.js
@@ -59,7 +59,9 @@ export class Comment {
    * @param {string} commentUrl
    */
   static bulkFetch(article, comments, commentUrl = context['comments_uri']) {
-    axios.get(commentUrl, {article_name: article.name})
+    axios.get(commentUrl, {
+      params: {article_name: article.name},
+    })
         .then((response) => {
           response.data.forEach((commentFetched) => {
             try {

--- a/emwiki/templates/base.html
+++ b/emwiki/templates/base.html
@@ -91,13 +91,9 @@
       </v-main>
     </v-app>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW"
-    crossorigin="anonymous"></script>
 
   <!-- base CSS, JavaScript -->
-  <link rel='stylesheet' href="{% static 'css/base.css' %}" type='text/css'>
-  </link>
+  <link rel='stylesheet' href="{% static 'css/base.css' %}" type='text/css'></link>
   {% block foot %}
   <script src="{% static 'js/main.js' %}"></script>
   {% endblock %}

--- a/emwiki/templates/base.html
+++ b/emwiki/templates/base.html
@@ -18,10 +18,10 @@
 
   <!-- Vuetify -->
   <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/@mdi/font@6.5.95/css/materialdesignicons.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/vuetify@2.6.4/dist/vuetify.min.css" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
-  <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vuetify@2.6.4/dist/vuetify.js"></script>
 
   <!-- Axios -->
   <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>


### PR DESCRIPTION
## 目的
#270 を解決する。

## 関連するIssue等
+ Fix #270 

## レビューポイント
+ Vuetify, @mdi/fontのバージョンを指定しました
     Vuetifyはボタンのアイコン等を表示するのに@mdi/fontというパッケージを使用しているのですが、@mdi/fontが最新のバージョン(6.6.95)であるときに #270 が発生していました。一つ前のバージョン(6.5.95)を指定することで解決しました。

+ articleでコメントをfetchする際のgetパラメーターを正しく設定しました。
+ 不要なjavascript読み込みを削除しました(Bootstrapの消し忘れ)

## 留意事項
+ 

## 残課題
+ 