### PR TITLE
Improve symbol page transition

### DIFF
--- a/emwiki/symbol/static/symbol/js/components/SymbolDrawer.js
+++ b/emwiki/symbol/static/symbol/js/components/SymbolDrawer.js
@@ -21,9 +21,8 @@ export const SymbolDrawer = {
   },
   methods: {
     onSymbolRowClick(row) {
-      if (this.$route.params.name !== row.name) {
-        this.$router.push({name: 'Symbol', params: {name: row.name}});
-      }
+      this.$router.push({name: 'Symbol', params: {name: row.name}});
+      window.scroll({top: 0, behavior: 'smooth'});
     },
   },
   watch: {

--- a/emwiki/symbol/static/symbol/js/views/SymbolView.js
+++ b/emwiki/symbol/static/symbol/js/views/SymbolView.js
@@ -18,17 +18,15 @@ export const SymbolView = {
       this.symbolName = name;
       this.jumpTo(name, hash);
     },
-    jumpTo(name, anchor) {
+    jumpTo(name, hash) {
       SymbolService.getHtml(context['symbol_html_uri'], name)
           .then((symbolHtml) => {
             this.compiled = Vue.compile(symbolHtml);
             this.$nextTick(() => {
-              const anchorName = anchor.split('#')[1];
-              if (anchorName) {
-                this.anchorElement = document.getElementById(anchorName);
-              } else {
-                window.scroll({top: 0, behavior: 'smooth'});
-              }
+              const anchorName = hash.replace('#', '');
+              this.anchorElement = anchorName ?
+                document.getElementById(anchorName) :
+                null;
             });
           });
     },
@@ -41,8 +39,10 @@ export const SymbolView = {
       if (oldVal) {
         oldVal.classList.remove('selected');
       }
-      newVal.classList.add('selected');
-      newVal.scrollIntoView();
+      if (newVal) {
+        newVal.classList.add('selected');
+        newVal.scrollIntoView();
+      }
     },
   },
   template: `


### PR DESCRIPTION
## 目的
Symbolのページ遷移を改善する
## 関連するIssue等
+ 

## レビューポイント
+ symbolページを開き, スクロールした状態で, サイドバーで同じsymbolのボタンをクリックすると, トップにスクロールされるようにしました.
+ symbolページ内のアンカーをクリックし, ブラウザの「戻る」ボタンをクリックしたとき, アンカーの選択状態が解除されないバグを修正しました.

## 留意事項
+ 

## 残課題
+ 