### PR TITLE
Fix article tooltip

### DIFF
--- a/emwiki/article/static/article/js/htmlized_mml.js
+++ b/emwiki/article/static/article/js/htmlized_mml.js
@@ -162,8 +162,8 @@ var tooltip = function() {
       }, timer);
     },
     pos: function(e) {
-      const u = ie ? event.clientY + document.documentElement.scrollTop : e.pageY;
-      const l = ie ? event.clientX + document.documentElement.scrollLeft : e.pageX;
+      const u = ie ? event.clientY + document.documentElement.scrollTop : e.clientY;
+      const l = ie ? event.clientX + document.documentElement.scrollLeft : e.clientX;
       tt.style.top = (u - h) + 'px';
       tt.style.left = (l + left) + 'px';
     },


### PR DESCRIPTION
## 目的
Articleでproof等にホバーした際に, 表示されるtooltipの位置がおかしい, もしくはtooltipが表示されない(ページをスクロールすると発生します)バグを修正する
![tt](https://user-images.githubusercontent.com/60038502/168049139-755b54dc-5229-4c0f-a30d-2ce9a4a44ae7.png)
## 関連するIssue等
+ 

## レビューポイント
+ 

## 留意事項


+ 

## 残課題
+ 